### PR TITLE
TDEM waveform for SimPEG

### DIFF
--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -75,16 +75,6 @@ class RawWaveform(BaseWaveform):
         return self.waveFct(time)
 
 
-class TriangularWaveform(BaseWaveform):
-    def __init__(self, offTime=0.0):
-        BaseWaveform.__init__(self, offTime, hasInitialFields=True)
-
-    def eval(self, time):
-        raise NotImplementedError(
-            "TriangularWaveform has not been implemented, you should write it!"
-        )
-
-
 class VTEMWaveform(BaseWaveform):
 
     offTime = properties.Float("off-time of the source", default=4.2e-3)
@@ -151,6 +141,21 @@ class TrapezoidWaveform(BaseWaveform):
             )
         else:
             return 0
+
+
+class TriangularWaveform(TrapezoidWaveform):
+    """
+    TriangularWaveform is a special case of TrapezoidWaveform where there's no pleateau
+    """
+
+    offTime = properties.Float("off-time of the source")
+    peakTime = properties.Float("Time at which the Triangular waveform is at its peak")
+
+    def __init__(self, **kwargs):
+        super(TriangularWaveform, self).__init__(**kwargs)
+        self.hasInitialFields = False
+        self.ramp_on = np.r_[0.0, self.peakTime]
+        self.ramp_off = np.r_[self.peakTime, self.offTime]
 
 
 class QuarterSineRampOnWaveform(BaseWaveform):

--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -47,7 +47,7 @@ class StepOffWaveform(BaseWaveform):
         BaseWaveform.__init__(self, offTime=offTime, hasInitialFields=True)
 
     def eval(self, time):
-        if abs(time - 0.0) < self.eps:
+        if abs(time - self.offTime) < self.eps:
             return 1.0
         else:
             return 0.0

--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -190,6 +190,43 @@ class QuarterSineRampOnWaveform(BaseWaveform):
             return 0
 
 
+class HalfSineWaveform(BaseWaveform):
+    """
+    A waveform that has a quarter-sine ramp-on and a quarter-cosine ramp-off.
+    When the end of ramp-on and start of ramp off are on the same spot, it looks
+    like a half sine wave.
+    """
+
+    ramp_on = properties.Array(
+        "times over which the transmitter ramps on", shape=(2,), dtype=float
+    )
+    ramp_off = properties.Array(
+        "times over which we ramp off the waveform", shape=(2,), dtype=float
+    )
+
+    def __init__(self, **kwargs):
+        super(HalfSineWaveform, self).__init__(**kwargs)
+        self.hasInitialFields = False
+
+    def eval(self, time):
+        if time < self.ramp_on[0]:
+            return 0
+        elif time >= self.ramp_on[0] and time <= self.ramp_on[1]:
+            return np.sin(
+                (np.pi / 2)
+                * ((time - self.ramp_on[0]) / (self.ramp_on[1] - self.ramp_on[0]))
+            )
+        elif time > self.ramp_on[1] and time < self.ramp_off[0]:
+            return 1
+        elif time >= self.ramp_off[0] and time <= self.ramp_off[1]:
+            return np.cos(
+                (np.pi / 2)
+                * ((time - self.ramp_off[0]) / (self.ramp_off[1] - self.ramp_off[0]))
+            )
+        else:
+            return 0
+
+
 ###############################################################################
 #                                                                             #
 #                                    Sources                                  #

--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -47,7 +47,7 @@ class StepOffWaveform(BaseWaveform):
         BaseWaveform.__init__(self, offTime=offTime, hasInitialFields=True)
 
     def eval(self, time):
-        if abs(time - self.offTime) < self.eps:
+        if abs(time - 0.0) < self.eps:
             return 1.0
         else:
             return 0.0

--- a/examples/06-tdem/plot_fwd_tdem_waveforms.py
+++ b/examples/06-tdem/plot_fwd_tdem_waveforms.py
@@ -21,7 +21,11 @@ vtem = TDEM.Src.VTEMWaveform()
 trapezoid = TDEM.Src.TrapezoidWaveform(
     ramp_on=np.r_[0.0, 1.5e-3], ramp_off=max_t - np.r_[1.5e-3, 0]
 )
+triangular = TDEM.Src.TriangularWaveform(peakTime=max_t / 2, offTime=max_t)
 quarter_sine = TDEM.Src.QuarterSineRampOnWaveform(
+    ramp_on=np.r_[0.0, 1.5e-3], ramp_off=max_t - np.r_[1.5e-3, 0]
+)
+half_sine = TDEM.Src.HalfSineWaveform(
     ramp_on=np.r_[0.0, 1.5e-3], ramp_off=max_t - np.r_[1.5e-3, 0]
 )
 
@@ -29,16 +33,18 @@ waveforms = dict(
     zip(
         [
             "RampOffWaveform",
-            "VTEMWaveform",
             "TrapezoidWaveform",
             "QuarterSineRampOnWaveform",
+            "VTEMWaveform",
+            "TriangularWaveform",
+            "HalfSineWaveform",
         ],
-        [ramp_off, vtem, trapezoid, quarter_sine],
+        [ramp_off, trapezoid, quarter_sine, vtem, triangular, half_sine],
     )
 )
 
 # plot the waveforms
-fig, ax = plt.subplots(2, 2, figsize=(7, 7))
+fig, ax = plt.subplots(3, 2, figsize=(7, 10))
 ax = mkvc(ax)
 
 for a, key in zip(ax, waveforms):

--- a/tests/em/tdem/test_TDEM_sources.py
+++ b/tests/em/tdem/test_TDEM_sources.py
@@ -5,9 +5,9 @@ from numpy.testing import assert_array_almost_equal
 from SimPEG.electromagnetics.time_domain.sources import (
     StepOffWaveform,
     RampOffWaveform,
-    TriangularWaveform,
     VTEMWaveform,
     TrapezoidWaveform,
+    TriangularWaveform,
     QuarterSineRampOnWaveform,
     HalfSineWaveform,
 )
@@ -91,6 +91,24 @@ class TestTrapezoidWaveform(unittest.TestCase):
         )
         result = [trapezoid.eval(t) for t in self.times]
         expected = np.array([0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 0.75, 0.5, 0.25, 0.0])
+        assert_array_almost_equal(result, expected)
+
+
+class TestTriangularWaveform(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.times = np.linspace(start=0, stop=1e-2, num=11)
+
+    def test_waveform_with_symmetric_on_off(self):
+        triangular = TriangularWaveform(peakTime=4e-3, offTime=8e-3)
+        result = [triangular.eval(t) for t in self.times]
+        expected = np.array([0.0, 0.25, 0.5, 0.75, 1.0, 0.75, 0.5, 0.25, 0.0, 0.0, 0.0])
+        assert_array_almost_equal(result, expected)
+
+    def test_waveform_with_asymmetric_on_off(self):
+        triangular = TriangularWaveform(peakTime=2e-3, offTime=6e-3)
+        result = [triangular.eval(t) for t in self.times]
+        expected = np.array([0.0, 0.5, 1.0, 0.75, 0.5, 0.25, 0.0, 0.0, 0.0, 0.0, 0.0])
         assert_array_almost_equal(result, expected)
 
 

--- a/tests/em/tdem/test_TDEM_sources.py
+++ b/tests/em/tdem/test_TDEM_sources.py
@@ -140,7 +140,6 @@ class TestQuarterSineRampOnWaveform(unittest.TestCase):
         assert_array_almost_equal(result, expected)
 
     def test_waveform_negative_plateau(self):
-        """TODO: should this throw a ValueError instead?"""
         quarter_sine = QuarterSineRampOnWaveform(
             ramp_on=np.r_[0.0, 8e-3], ramp_off=np.r_[2e-3, 1e-2]
         )

--- a/tests/em/tdem/test_TDEM_sources.py
+++ b/tests/em/tdem/test_TDEM_sources.py
@@ -3,9 +3,32 @@ import unittest
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from SimPEG.electromagnetics.time_domain.sources import (
-    HalfSineWaveform,
+    StepOffWaveform,
+    RampOffWaveform,
+    TriangularWaveform,
+    VTEMWaveform,
+    TrapezoidWaveform,
     QuarterSineRampOnWaveform,
+    HalfSineWaveform,
 )
+
+
+class TestStepOffWaveform(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.times = np.linspace(start=0, stop=1e-2, num=11)
+
+    def test_waveform_with_default_eps(self):
+        step_off = StepOffWaveform()
+        result = [step_off.eval(t) for t in self.times]
+        expected = np.array([1.0] + [0.0] * 10)
+        assert_array_almost_equal(result, expected)
+
+    def test_waveform_with_custom_off_time(self):
+        step_off = StepOffWaveform(offTime=1e-3)
+        result = [step_off.eval(t) for t in self.times]
+        expected = np.array([0.0, 1.0] + [0.0] * 9)
+        assert_array_almost_equal(result, expected)
 
 
 class TestQuarterSineRampOnWaveform(unittest.TestCase):

--- a/tests/em/tdem/test_TDEM_sources.py
+++ b/tests/em/tdem/test_TDEM_sources.py
@@ -18,16 +18,79 @@ class TestStepOffWaveform(unittest.TestCase):
     def setUpClass(cls):
         cls.times = np.linspace(start=0, stop=1e-2, num=11)
 
-    def test_waveform_with_default_eps(self):
+    def test_waveform_with_default_off_time(self):
         step_off = StepOffWaveform()
         result = [step_off.eval(t) for t in self.times]
         expected = np.array([1.0] + [0.0] * 10)
         assert_array_almost_equal(result, expected)
 
     def test_waveform_with_custom_off_time(self):
+        """For StepOffWaveform, offTime arg does not do anything."""
         step_off = StepOffWaveform(offTime=1e-3)
         result = [step_off.eval(t) for t in self.times]
-        expected = np.array([0.0, 1.0] + [0.0] * 9)
+        expected = np.array([1.0] + [0.0] * 10)
+        assert_array_almost_equal(result, expected)
+
+
+class TestRampOffWaveform(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.times = np.linspace(start=0, stop=1e-2, num=11)
+
+    def test_waveform_with_whole_offtime(self):
+        ramp_off = RampOffWaveform(offTime=1e-2)
+        result = [ramp_off.eval(t) for t in self.times]
+        expected = np.array([1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0])
+        assert_array_almost_equal(result, expected)
+
+    def test_waveform_with_partial_off_time(self):
+        ramp_off = RampOffWaveform(offTime=5e-3)
+        result = [ramp_off.eval(t) for t in self.times]
+        expected = np.array([1.0, 0.8, 0.6, 0.4, 0.2, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        assert_array_almost_equal(result, expected)
+
+
+class TestVTEMWaveform(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.times = np.linspace(start=0, stop=1e-2, num=11)
+
+    def test_waveform_with_default_param(self):
+        vtem = VTEMWaveform()
+        result = [vtem.eval(t) for t in self.times]
+        expected = np.array(
+            [0.0, 0.701698, 0.93553, 0.816327, 0.136054, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        )
+        assert_array_almost_equal(result, expected)
+
+    def test_waveform_with_custom_param(self):
+        vtem = VTEMWaveform(offTime=8e-3, peakTime=4e-3, a=2.0)
+        result = [vtem.eval(t) for t in self.times]
+        expected = np.array(
+            [0.0, 0.455054, 0.731059, 0.898464, 1.0, 0.75, 0.5, 0.25, 0.0, 0.0, 0.0]
+        )
+        assert_array_almost_equal(result, expected)
+
+
+class TestTrapezoidWaveform(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.times = np.linspace(start=0, stop=1e-2, num=11)
+
+    def test_waveform_with_symmetric_on_off(self):
+        trapezoid = TrapezoidWaveform(
+            ramp_on=np.r_[0.0, 2e-3], ramp_off=np.r_[6e-3, 8e-3]
+        )
+        result = [trapezoid.eval(t) for t in self.times]
+        expected = np.array([0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.0, 0.0, 0.0])
+        assert_array_almost_equal(result, expected)
+
+    def test_waveform_with_asymmetric_on_off(self):
+        trapezoid = TrapezoidWaveform(
+            ramp_on=np.r_[0.0, 2e-3], ramp_off=np.r_[6e-3, 10e-3]
+        )
+        result = [trapezoid.eval(t) for t in self.times]
+        expected = np.array([0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 0.75, 0.5, 0.25, 0.0])
         assert_array_almost_equal(result, expected)
 
 

--- a/tests/em/tdem/test_TDEM_sources.py
+++ b/tests/em/tdem/test_TDEM_sources.py
@@ -1,0 +1,100 @@
+import unittest
+
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+from SimPEG.electromagnetics.time_domain.sources import (
+    HalfSineWaveform,
+    QuarterSineRampOnWaveform,
+)
+
+
+class TestQuarterSineRampOnWaveform(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.times = np.linspace(start=0, stop=1e-2, num=11)
+
+    def test_waveform_with_plateau(self):
+        quarter_sine = QuarterSineRampOnWaveform(
+            ramp_on=np.r_[0.0, 3e-3], ramp_off=np.r_[7e-3, 1e-2]
+        )
+        result = [quarter_sine.eval(t) for t in self.times]
+        expected = np.array(
+            [0.0, 0.5, 0.866025, 1.0, 1.0, 1.0, 1.0, 1.0, 0.666667, 0.333333, 0.0]
+        )
+
+        assert_array_almost_equal(result, expected)
+
+    def test_waveform_without_plateau(self):
+        quarter_sine = QuarterSineRampOnWaveform(
+            ramp_on=np.r_[0.0, 5e-3], ramp_off=np.r_[5e-3, 1e-2]
+        )
+        result = [quarter_sine.eval(t) for t in self.times]
+        expected = np.array(
+            [0.0, 0.309017, 0.587785, 0.809017, 0.951057, 1.0, 0.8, 0.6, 0.4, 0.2, 0.0]
+        )
+
+        assert_array_almost_equal(result, expected)
+
+    def test_waveform_negative_plateau(self):
+        """TODO: should this throw a ValueError instead?"""
+        quarter_sine = QuarterSineRampOnWaveform(
+            ramp_on=np.r_[0.0, 8e-3], ramp_off=np.r_[2e-3, 1e-2]
+        )
+        result = [quarter_sine.eval(t) for t in self.times]
+        expected = np.array(
+            [
+                0.0,
+                0.19509,
+                0.382683,
+                0.55557,
+                0.707107,
+                0.83147,
+                0.92388,
+                0.980785,
+                1.0,
+                0.125,
+                0.0,
+            ]
+        )
+
+        assert_array_almost_equal(result, expected)
+
+
+class TestHalfSineWaveform(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.times = np.linspace(start=0, stop=1e-2, num=11)
+
+    def test_waveform_with_plateau(self):
+        half_sine = HalfSineWaveform(
+            ramp_on=np.r_[0.0, 3e-3], ramp_off=np.r_[7e-3, 1e-2]
+        )
+        result = [half_sine.eval(t) for t in self.times]
+        expected = np.array(
+            [0.0, 0.5, 0.866025, 1.0, 1.0, 1.0, 1.0, 1.0, 0.866025, 0.5, 0.0]
+        )
+
+        assert_array_almost_equal(result, expected)
+
+    def test_waveform_without_plateau(self):
+        half_sine = HalfSineWaveform(
+            ramp_on=np.r_[0.0, 5e-3], ramp_off=np.r_[5e-3, 1e-2]
+        )
+        result = [half_sine.eval(t) for t in self.times]
+        expected = np.array(
+            [
+                0.0,
+                0.309017,
+                0.587785,
+                0.809017,
+                0.951057,
+                1.0,
+                0.951057,
+                0.809017,
+                0.587785,
+                0.309017,
+                0.0,
+            ]
+        )
+
+        assert_array_almost_equal(result, expected)


### PR DESCRIPTION
This PR adds the following functionalities for SimPEG: 

* Two new SimPEG waveforms, `HalfSineWaveform` and `TriangularWaveform`. The latter was originally left by SimPEG as an "exercise to the reader"; I made it inherit `TrapezoidWaveform` so we can just reuse the same code.
* Unit tests for most TDEM waveforms (which I couldn't find in the SimPEG repo, so adding them for completeness)

The unit test was written with `unittest` framework (as opposed to `pytest`), and the code is formatted with `black`'s default setting, to comply with `simpeg`'s contribution guidelines: https://docs.simpeg.xyz/content/basic/contributing.html.

I'll wait until both @jedman and @j-d-goldman has approved this PR, before submitting the PR to the main simpeg repo (related issue: https://github.com/simpeg/simpeg/issues/893).