### PR TITLE
Modification to survey setup to get inversion to run on dask yarn cluster

### DIFF
--- a/SimPEG/directives.py
+++ b/SimPEG/directives.py
@@ -297,8 +297,8 @@ class SaveEveryIteration(InversionDirective):
     """SaveEveryIteration
 
     This directive saves an array at each iteration. The default
-    direcroty is the current directoy and the models are saved as
-    `InversionModel-YYYY-MM-DD-HH-MM-iter.npy`
+    directory is the current directoy and the models are saved as
+    ``InversionModel-YYYY-MM-DD-HH-MM-iter.npy``
     """
 
     directory = properties.String("directory to save results in", default=".")
@@ -330,8 +330,8 @@ class SaveModelEveryIteration(SaveEveryIteration):
     """SaveModelEveryIteration
 
     This directive saves the model as a numpy array at each iteration. The
-    default direcroty is the current directoy and the models are saved as
-    `InversionModel-YYYY-MM-DD-HH-MM-iter.npy`
+    default directory is the current directoy and the models are saved as
+    ``InversionModel-YYYY-MM-DD-HH-MM-iter.npy``
     """
 
     def initialize(self):
@@ -560,7 +560,7 @@ class SaveOutputEveryIteration(SaveEveryIteration):
 
 class SaveOutputDictEveryIteration(SaveEveryIteration):
     """
-        Saves inversion parameters at every iteraion.
+        Saves inversion parameters at every iteration.
     """
 
     # Initialize the output dict
@@ -586,7 +586,6 @@ class SaveOutputDictEveryIteration(SaveEveryIteration):
         #     regCombo += ["phi_msz"]
 
         # Initialize the output dict
-        iterDict = None
         iterDict = {}
 
         # Save the data.

--- a/SimPEG/survey.py
+++ b/SimPEG/survey.py
@@ -253,6 +253,7 @@ class BaseSurvey(properties.HasProperties):
 
     def __init__(self, source_list=None, **kwargs):
         super(BaseSurvey, self).__init__(**kwargs)
+        self._sourceOrder = dict()
         if source_list is not None:
             self.source_list = source_list
 
@@ -261,7 +262,7 @@ class BaseSurvey(properties.HasProperties):
         value = change["value"]
         if len(set(value)) != len(value):
             raise Exception("The source_list must be unique")
-        self._sourceOrder = dict()
+        # self._sourceOrder = dict()
         [self._sourceOrder.setdefault(src._uid, ii) for ii, src in enumerate(value)]
 
     # TODO: this should be private

--- a/SimPEG/survey.py
+++ b/SimPEG/survey.py
@@ -262,7 +262,7 @@ class BaseSurvey(properties.HasProperties):
         value = change["value"]
         if len(set(value)) != len(value):
             raise Exception("The source_list must be unique")
-        # self._sourceOrder = dict()
+
         [self._sourceOrder.setdefault(src._uid, ii) for ii, src in enumerate(value)]
 
     # TODO: this should be private
@@ -270,9 +270,14 @@ class BaseSurvey(properties.HasProperties):
         if type(sources) is not list:
             sources = [sources]
 
-        for src in sources:
+        for ii, src in enumerate(sources):
             if getattr(src, "_uid", None) is None:
                 raise KeyError("Source does not have a _uid: {0!s}".format(str(src)))
+
+            # Set default value for _sourceOrder because on dask yarn cluster,
+            # _source_list_validator does not always run on all workers for some reason
+            self._sourceOrder.setdefault(src._uid, ii)
+
         inds = list(map(lambda src: self._sourceOrder.get(src._uid, None), sources))
         if None in inds:
             raise KeyError(


### PR DESCRIPTION
This PR moves around the location of of two lines of code in `self._sourceOrder` for surveys.

Symptom: when parallelizing inversions on dask yarn cluster, `_source_list_validator` function does not always run on all dask workers. Therefore we always encountered one of the two exceptions: 
`AttributeError("'Survey' object has no attribute '_sourceOrder'")` or `KeyError('Some of the sources specified are not in this survey. [None]')`.

It should be noted that we were able to only observe this behavior when trying to parallelize computation on dask yarn cluster; a local cluster (on a single machine) does not seem to suffer this bug.

Moving how we set `self._sourceOrder` to `__init__` and add an additional remedial step of `self._sourceOrder.setdefault` appears to have fixed the symptoms we observed.

I'll wait until both @jedman and @j-d-goldman has approved this PR, before submitting the PR to the main simpeg repo.