### PR TITLE
Dev/jpe nsem data fix

### DIFF
--- a/SimPEG/electromagnetics/natural_source/survey.py
+++ b/SimPEG/electromagnetics/natural_source/survey.py
@@ -255,4 +255,7 @@ def _rec_to_ndarr(rec_arr, data_type=float):
     """
     Function to transform a numpy record array to a nd array.
     """
-    return rec_arr.view((data_type, len(rec_arr.dtype.names)))
+    # fix for numpy >= 1.16.0
+    # https://stackoverflow.com/questions/57183977/broken-structured-to-unstructured-numpy-array-conversion-in-1-16-0
+    return np.array(recFunc.structured_to_unstructured(recFunc.repack_fields(rec_arr[list(rec_arr.dtype.names)])),
+                    dtype=data_type)

--- a/SimPEG/electromagnetics/natural_source/survey.py
+++ b/SimPEG/electromagnetics/natural_source/survey.py
@@ -256,6 +256,6 @@ def _rec_to_ndarr(rec_arr, data_type=float):
     dupe of SimPEG.electromagnetics.natural_source.utils.rec_to_ndarr to avoid circular import
     """
     # fix for numpy >= 1.16.0
-    # https://stackoverflow.com/questions/57183977/broken-structured-to-unstructured-numpy-array-conversion-in-1-16-0
+    # https://numpy.org/devdocs/release/1.16.0-notes.html#multi-field-views-return-a-view-instead-of-a-copy
     return np.array(recFunc.structured_to_unstructured(recFunc.repack_fields(rec_arr[list(rec_arr.dtype.names)])),
                     dtype=data_type)

--- a/SimPEG/electromagnetics/natural_source/survey.py
+++ b/SimPEG/electromagnetics/natural_source/survey.py
@@ -8,7 +8,6 @@ from ...utils import mkvc
 from .sources import Planewave_xy_1Dprimary, Planewave_xy_1DhomotD
 from .receivers import Point3DImpedance, Point3DTipper
 from .utils.plot_utils import DataNSEMPlotMethods
-
 #########
 # Survey
 #########
@@ -254,6 +253,7 @@ class Data(BaseData, DataNSEMPlotMethods):
 def _rec_to_ndarr(rec_arr, data_type=float):
     """
     Function to transform a numpy record array to a nd array.
+    dupe of SimPEG.electromagnetics.natural_source.utils.rec_to_ndarr to avoid circular import
     """
     # fix for numpy >= 1.16.0
     # https://stackoverflow.com/questions/57183977/broken-structured-to-unstructured-numpy-array-conversion-in-1-16-0

--- a/SimPEG/electromagnetics/natural_source/utils/data_utils.py
+++ b/SimPEG/electromagnetics/natural_source/utils/data_utils.py
@@ -311,7 +311,7 @@ def rec_to_ndarr(rec_arr, data_type=float):
     """
     Function to transform a numpy record array to a nd array.
     """
-    # fix for numpy >= 1.16.0
+    # fix for numpy >= 1.16.0 with masked arrays
     # https://stackoverflow.com/questions/57183977/broken-structured-to-unstructured-numpy-array-conversion-in-1-16-0
     return np.array(recFunc.structured_to_unstructured(recFunc.repack_fields(rec_arr[list(rec_arr.dtype.names)])),
                     dtype=data_type)

--- a/SimPEG/electromagnetics/natural_source/utils/data_utils.py
+++ b/SimPEG/electromagnetics/natural_source/utils/data_utils.py
@@ -311,7 +311,10 @@ def rec_to_ndarr(rec_arr, data_type=float):
     """
     Function to transform a numpy record array to a nd array.
     """
-    return rec_arr.copy().view((data_type, len(rec_arr.dtype.names)))
+    # fix for numpy >= 1.16.0
+    # https://stackoverflow.com/questions/57183977/broken-structured-to-unstructured-numpy-array-conversion-in-1-16-0
+    return np.array(recFunc.structured_to_unstructured(recFunc.repack_fields(rec_arr[list(rec_arr.dtype.names)])),
+                    dtype=data_type)
 
 
 def makeAnalyticSolution(mesh, model, elev, freqs):

--- a/SimPEG/electromagnetics/natural_source/utils/data_utils.py
+++ b/SimPEG/electromagnetics/natural_source/utils/data_utils.py
@@ -312,7 +312,7 @@ def rec_to_ndarr(rec_arr, data_type=float):
     Function to transform a numpy record array to a nd array.
     """
     # fix for numpy >= 1.16.0 with masked arrays
-    # https://stackoverflow.com/questions/57183977/broken-structured-to-unstructured-numpy-array-conversion-in-1-16-0
+    # https://numpy.org/devdocs/release/1.16.0-notes.html#multi-field-views-return-a-view-instead-of-a-copy
     return np.array(recFunc.structured_to_unstructured(recFunc.repack_fields(rec_arr[list(rec_arr.dtype.names)])),
                     dtype=data_type)
 

--- a/tests/em/nsem/survey/test_nsem_data.py
+++ b/tests/em/nsem/survey/test_nsem_data.py
@@ -34,5 +34,5 @@ class TestNSEMData:
         for src in data_obj.survey.source_list:
             assert len(src.receiver_list) == 2  # one real, one imaginary component
             for rx in src.receiver_list:
-                np.testing.assert_almost_equal(rx.locations, self.loc)
+                np.testing.assert_almost_equal(rx.locations, [self.loc])
         np.testing.assert_almost_equal(data_obj.dobs, np.array([0.5, 0.0, 0.5, 1.0]))

--- a/tests/em/nsem/survey/test_nsem_data.py
+++ b/tests/em/nsem/survey/test_nsem_data.py
@@ -1,0 +1,38 @@
+import numpy as np
+from SimPEG.electromagnetics.natural_source.survey import Data
+
+
+class TestNSEMData:
+    @classmethod
+    def setup_class(cls):
+        cls.freqs = [0.01, 0.05]
+        cls.loc = [48.0, -98.0, 100.0]
+        data_types = [
+            ("freq", float),
+            ("x", float),
+            ("y", float),
+            ("z", float),
+            ("zxxr", float),
+            ("zxxi", float),
+        ]
+        full_array = np.array(
+            [
+                [[cls.freqs[0], cls.loc[0], cls.loc[1], cls.loc[2], 5.0e-01, 0.0e00]],
+                [[cls.freqs[1], cls.loc[0], cls.loc[1], cls.loc[2], 5.0e-01, 1.0e00]],
+            ]
+        )
+        cls.rec_array = np.ma.masked_array(full_array, mask=np.isnan(full_array)).view(
+            data_types
+        )
+
+    def test_from_rec_array(self):
+        """test for class instantiation from a record array"""
+
+        data_obj = Data.fromRecArray(recArray=self.rec_array)
+        assert data_obj.survey.frequencies == self.freqs
+        assert len(data_obj.survey.source_list) == 2
+        for src in data_obj.survey.source_list:
+            assert len(src.receiver_list) == 2  # one real, one imaginary component
+            for rx in src.receiver_list:
+                np.testing.assert_almost_equal(rx.locations, self.loc)
+        np.testing.assert_almost_equal(data_obj.dobs, np.array([0.5, 0.0, 0.5, 1.0]))

--- a/tests/em/nsem/utils/test_data_utils.py
+++ b/tests/em/nsem/utils/test_data_utils.py
@@ -1,0 +1,9 @@
+import numpy as np
+from SimPEG.electromagnetics.natural_source.utils.data_utils import rec_to_ndarr
+
+
+def test_rec_to_ndarr():
+    sample_rec_arr = np.ma.masked_array(data=[(1, 3), (2, 4)], dtype=[('a', int), ('b', float)])
+    res = rec_to_ndarr(rec_arr=sample_rec_arr, data_type=float)
+    exp_nd_array = np.array([[1, 3], [2, 4]], dtype=float)
+    np.testing.assert_almost_equal(res, exp_nd_array)


### PR DESCRIPTION
In modern (>= 1.16) versions of numpy, multifield indexing returns a view rather than a copy (https://numpy.org/devdocs/release/1.16.0-notes.html#multi-field-views-return-a-view-instead-of-a-copy), which breaks some code that converts between structured and unstructured arrays in SimPEG. 

Specifically, when trying to convert a subset of a structured array (the contents of a masked array, say, but not the mask) to an `ndarray`, the following error is raised `ValueError: Changing the dtype to a subarray type is only supported if the total itemsize is unchanged`

This PR has a fix, plus some new tests.